### PR TITLE
Update xiaomi-spes.yaml - paranoidandroid and evolutionX

### DIFF
--- a/database/phone_data/xiaomi-spes.yaml
+++ b/database/phone_data/xiaomi-spes.yaml
@@ -28,11 +28,18 @@ roms:
     phone-webpage: 'https://crdroid.net/downloads#spes'
   - 
     rom-name: 'EvolutionX'
-    rom-support: true
+    rom-support: false
     rom-state: 'Official'
     android-version: '13'
     rom-webpage: 'https://evolution-x.org/'
     phone-webpage: 'https://evolution-x.org/device/spes'
+  -
+    rom-name: 'paranoidandroid'
+    rom-support: true
+    rom-state: 'Official'
+    android-version: '13'
+    rom-webpage: 'https://paranoidandroid.co/'
+    phone-webpage: 'https://paranoidandroid.co/spes'
   - 
     rom-name: 'SuperiorOS'
     rom-support: true


### PR DESCRIPTION
Added paranoidandroid https://paranoidandroid.co/spes

changed EvolutionX to false because the webpage appears to 404 https://evolution-x.org/device/spes  (unless its supposed to be discontinued but i can't find information about this on the page)

Also while some other roms technically stopped updating I think its better to wait for them because Xiaomi only recently released the device sources so they might restart soon hopefully.